### PR TITLE
Update Cargo.toml remove www

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 authors = ["Tobias Decking"]
 readme = "README.md"
 license = "MIT OR Apache-2.0"
-repository = "https://www.github.com/TDecking/m61-modulus"
+repository = "https://github.com/TDecking/m61-modulus"
 
 keywords = ["bignum", "bigint", "mathematics"]
 categories = ["algorithms", "mathematics", "no-std"]


### PR DESCRIPTION
The website redirects anyway, so it might be better to link to the destination